### PR TITLE
增加消息类型TrajectoryWithGoal

### DIFF
--- a/autoware_auto_planning_msgs/CMakeLists.txt
+++ b/autoware_auto_planning_msgs/CMakeLists.txt
@@ -18,6 +18,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Route.idl"
   "msg/Trajectory.idl"
   "msg/TrajectoryPoint.idl"
+  "msg/TrajectoryWithGoal.idl"
   "msg/Path.idl"
   "msg/PathPoint.idl"
   "msg/PathWithLaneId.idl"

--- a/autoware_auto_planning_msgs/msg/TrajectoryWithGoal.idl
+++ b/autoware_auto_planning_msgs/msg/TrajectoryWithGoal.idl
@@ -1,19 +1,13 @@
-#include "autoware_auto_planning_msgs/msg/TrajectoryPoint.idl"
+#include "autoware_auto_planning_msgs/msg/Trajectory.idl"
 #include "std_msgs/msg/Header.idl"
 
 module autoware_auto_planning_msgs {
   module msg {
-    module Trajectory_Constants {
-      const uint32 CAPACITY = 10000;
-    };
     @verbatim (language="comment", text=
-      " A set of trajectory points for the controller")
+      " A set of trajectory points with goal for the obca")
     struct TrajectoryWithGoal {
-      std_msgs::msg::Header header;
-
       geometry_msgs::msg::PoseStamped goal;
-
-      sequence<autoware_auto_planning_msgs::msg::TrajectoryPoint, 10000> points;
+      autoware_auto_planning_msgs::msg::Trajectory trajectory;
     };
   };
 };

--- a/autoware_auto_planning_msgs/msg/TrajectoryWithGoal.idl
+++ b/autoware_auto_planning_msgs/msg/TrajectoryWithGoal.idl
@@ -1,0 +1,19 @@
+#include "autoware_auto_planning_msgs/msg/TrajectoryPoint.idl"
+#include "std_msgs/msg/Header.idl"
+
+module autoware_auto_planning_msgs {
+  module msg {
+    module Trajectory_Constants {
+      const uint32 CAPACITY = 10000;
+    };
+    @verbatim (language="comment", text=
+      " A set of trajectory points for the controller")
+    struct TrajectoryWithGoal {
+      std_msgs::msg::Header header;
+
+      geometry_msgs::msg::PoseStamped goal;
+
+      sequence<autoware_auto_planning_msgs::msg::TrajectoryPoint, 10000> points;
+    };
+  };
+};


### PR DESCRIPTION
为obca算法增加一个消息类型TrajectoryWithGoal
目的是OBCA算法参数上需要trajecotry同时也需要goal，但是使用现有消息类型很难保持数据的同步，因此增加消息类型来解决问题